### PR TITLE
#14 Added support for cross sbt version building, so we can publish for sbt 1.x.x series

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.github.borisnaguet"
 
 version := "0.2.6"
 
-scalaVersion := "2.10.6"
+crossSbtVersions := List("0.13.17", "1.1.1")
 
 publishMavenStyle := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.15
+sbt.version=1.1.1
 

--- a/src/main/scala/io/github/borisnaguet/sbt/plugins/CxfWsdl2JavaPlugin.scala
+++ b/src/main/scala/io/github/borisnaguet/sbt/plugins/CxfWsdl2JavaPlugin.scala
@@ -116,7 +116,7 @@ object CxfWsdl2JavaPlugin extends AutoPlugin {
         val cmd = Seq("java", "-cp", classpath) ++ sysProps ++ Seq("org.apache.cxf.tools.wsdlto.WSDLToJava") ++ args
 
         s.log.debug(cmd.toString())
-        cmd ! s.log
+        cmd.foreach(s.log(_))
         s.log.info("Finished " + id)
         IO.copyDirectory(output, (sourceManaged in CxfConfig).value, overwrite = true)
       }


### PR DESCRIPTION
This should add support for sbt version 1.x.x. Fixes #14 

The only other thing is the publishing has to be changed, but I'm not sure how your release flow is.

Calling `^ publish` instead of `publish` should now publish it in both sbt version 1.x.x and 0.13.x